### PR TITLE
Fix clang support when we use autotools

### DIFF
--- a/bin/qrintf
+++ b/bin/qrintf
@@ -62,6 +62,20 @@ if (basename($cc) =~ m{^g(?:cc|\+\+)}) {
 
     # splice "-o fn" from ARGV
     my $output_fn;
+    
+    # for autoconf(C89 comatibirity test) begin
+    for (my $i = 0; $i < @ARGV;) {
+        if ($i + 1 < @ARGV && $ARGV[$i] eq '-c') {
+            $output_fn = $ARGV[$i + 1];
+            $output_fn =~ s/\.c/\.o/;
+            #splice @ARGV, $i, 2;
+            ++$i;
+        } else {
+          ++$i;
+        }
+    }
+    # end
+    
     for (my $i = 0; $i < @ARGV;) {
         if ($i + 1 < @ARGV && $ARGV[$i] eq '-o') {
             $output_fn = $ARGV[$i + 1];


### PR DESCRIPTION
clang is compatible to C89,but without this patch,configure are mis understood compatiblity of C89.
